### PR TITLE
Sort UIKT blocks

### DIFF
--- a/APIWrapper/Objects/ScheduleHourContent.cs
+++ b/APIWrapper/Objects/ScheduleHourContent.cs
@@ -1,5 +1,6 @@
 using FRITeam.Swapify.APIWrapper.Enums;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace FRITeam.Swapify.APIWrapper.Objects
 {
@@ -75,6 +76,21 @@ namespace FRITeam.Swapify.APIWrapper.Objects
                     (RoomName == b2?.RoomName) &&
                     (LessonType == b2?.LessonType) &&
                     (StudyGroups.SetEquals(b2?.StudyGroups));
+        }
+
+        public int GetIndexOfSameBlockInList(List<ScheduleHourContent> blocksInDay)
+        {
+            if (!blocksInDay.Any()) return -2;
+
+            for (int curBlockIndex = 0; curBlockIndex < blocksInDay.Count; curBlockIndex++)
+            {
+                if (blocksInDay[curBlockIndex].IsSameBlockAs(this))
+                {
+                    return curBlockIndex;
+                }
+            }
+
+            return -1;
         }
     }
 }

--- a/APIWrapper/ResponseParser.cs
+++ b/APIWrapper/ResponseParser.cs
@@ -46,19 +46,15 @@ namespace FRITeam.Swapify.APIWrapper
 
                         //-1 because API count day 1,2,3,4,5 and we store days at indexes 0,1,2,3,4
                         var weekday = weekTimetable.DaysInWeek[int.Parse(block["dw"].ToString()) - 1];
-                        bool inserted = false;
-                        for (int curBlockIndex = 0; curBlockIndex < weekday.BlocksInDay.Count; curBlockIndex++)
-                        {
-                            if (weekday.BlocksInDay[curBlockIndex].IsSameBlockAs(sc))
-                            {
-                                weekday.BlocksInDay.Insert(curBlockIndex + 1, sc);
-                                inserted = true;
-                                break;
-                            }
-                        }
-                        if (!inserted)
+
+                        int index = sc.GetIndexOfSameBlockInList(weekday.BlocksInDay);
+                        if(index < 0)
                         {
                             weekday.BlocksInDay.Add(sc);
+                        }
+                        else
+                        {
+                            weekday.BlocksInDay.Insert(index + 1, sc);
                         }
                     }
                 }

--- a/APIWrapper/ResponseParser.cs
+++ b/APIWrapper/ResponseParser.cs
@@ -43,8 +43,23 @@ namespace FRITeam.Swapify.APIWrapper
                         var sc = new ScheduleHourContent(int.Parse(block["b"].ToString()), false,
                                                          lessonType, teacherName, roomName, subjectShortcut,
                                                          subjectName, SubjectType.None, new List<string>());
+
                         //-1 because API count day 1,2,3,4,5 and we store days at indexes 0,1,2,3,4
-                        weekTimetable.DaysInWeek[int.Parse(block["dw"].ToString()) - 1].BlocksInDay.Add(sc);
+                        var weekday = weekTimetable.DaysInWeek[int.Parse(block["dw"].ToString()) - 1];
+                        bool inserted = false;
+                        for (int curBlockIndex = 0; curBlockIndex < weekday.BlocksInDay.Count; curBlockIndex++)
+                        {
+                            if (weekday.BlocksInDay[curBlockIndex].IsSameBlockAs(sc))
+                            {
+                                weekday.BlocksInDay.Insert(curBlockIndex + 1, sc);
+                                inserted = true;
+                                break;
+                            }
+                        }
+                        if (!inserted)
+                        {
+                            weekday.BlocksInDay.Add(sc);
+                        }
                     }
                 }
                 catch (Exception ex)

--- a/Tests/BackendTest/ScheduleHourTest.cs
+++ b/Tests/BackendTest/ScheduleHourTest.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using FluentAssertions;
+using FRITeam.Swapify.APIWrapper.Enums;
+using FRITeam.Swapify.APIWrapper.Objects;
+using Xunit;
+
+namespace BackendTest
+{
+    public class ScheduleHourTest
+    {
+
+        [Fact]
+        public void CorrectSortingOfBlocks()
+        {
+            var meta = new ScheduleHourContent(1, false, LessonType.Laboratory, "Jan Janech", "RA045", "1181S",
+                "Metaprogramovanie", SubjectType.Elective, new List<string>());
+            var pas = new ScheduleHourContent(5, false, LessonType.Excercise, "Ida Stankovianska", "RB053", "11BA31",
+                "Pravdepodobnosť a štatistika", SubjectType.Compulsory, new List<string>());
+            var pas1 = new ScheduleHourContent(6, false, LessonType.Excercise, "Ida Stankovianska", "RB053", "11BA31",
+                "Pravdepodobnosť a štatistika", SubjectType.Compulsory, new List<string>());
+            var prog = new ScheduleHourContent(7, false, LessonType.Excercise, "Stefan Toth", "RA333", "11111",
+                "Programovanie", SubjectType.Compulsory, new List<string>());
+            var telesna = new ScheduleHourContent(7, false, LessonType.Excercise, "Dusan Giba", "T-1", "12121",
+                "Telesna", SubjectType.Optional, new List<string>());
+
+            List<ScheduleHourContent> list = new List<ScheduleHourContent>();
+            telesna.GetIndexOfSameBlockInList(list).Should().Be(-2);
+
+            list.Add(meta);
+            list.Add(pas);
+
+            pas1.GetIndexOfSameBlockInList(list).Should().Be(1);
+            prog.GetIndexOfSameBlockInList(list).Should().Be(-1);
+        }
+    }
+}

--- a/WebApp/package-lock.json
+++ b/WebApp/package-lock.json
@@ -2449,7 +2449,7 @@
         },
         "opn": {
           "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
           "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
           "dev": true,
           "requires": {
@@ -5141,7 +5141,7 @@
         },
         "finalhandler": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
           "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
           "dev": true,
           "requires": {
@@ -6118,7 +6118,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
     },
@@ -6585,7 +6585,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
@@ -7850,7 +7850,7 @@
         },
         "yargs": {
           "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
           "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
           "dev": true,
           "requires": {
@@ -8029,7 +8029,7 @@
     },
     "jest-get-type": {
       "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+      "resolved": "http://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
       "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
       "dev": true
     },
@@ -8327,7 +8327,7 @@
         },
         "yargs": {
           "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
           "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
           "dev": true,
           "requires": {
@@ -8802,7 +8802,7 @@
         },
         "yargs": {
           "version": "6.6.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+          "resolved": "http://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
           "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
           "dev": true,
           "requires": {
@@ -13394,7 +13394,7 @@
         },
         "strip-ansi": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
           "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
           "dev": true
         }
@@ -14932,7 +14932,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -15921,7 +15921,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }


### PR DESCRIPTION
Blocks obtained from UIKT had to be sorted to be displayed correctly in the schedule. Blocks are not splitted anymore. Problem fixed. 

![image](https://user-images.githubusercontent.com/43958473/53434123-2eb71800-39f6-11e9-9eb1-092acb503255.png)
