### PR TITLE
269-Set_copy_always_to_output_directory_for_exchange_template

### DIFF
--- a/Backend/Backend.csproj
+++ b/Backend/Backend.csproj
@@ -32,6 +32,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="Emails\EmailTemplates\ConfirmationExchangeTemplate.html">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="Emails\EmailTemplates\ConfirmEmailTemplate.html">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
1. When I created ConfirmationExchangeTemplate I'm forgot to set "Copy to Output Directory" property to "Copy always". I fixed it.