### PR TITLE
Issue 373

### DIFF
--- a/APIWrapper/ResponseParser.cs
+++ b/APIWrapper/ResponseParser.cs
@@ -39,8 +39,8 @@ namespace FRITeam.Swapify.APIWrapper
                         LessonType lessonType = ConvertLessonType(block["tu"].ToString()[0]);
                         string teacherName = block["u"].ToString();
                         string roomName = block["r"].ToString();
-                        string subjectShortcut = block["k"].ToString();
-                        string subjectNameHelper = block["s"].ToString();
+                        string subjectShortcut = block["k"].ToString().Trim();
+                        string subjectNameHelper = block["s"].ToString().Trim();
                         string subjectName = subjectNameHelper.First().ToString().ToUpper() + subjectNameHelper.Substring(1);
                         var hourContent = new ScheduleHourContent(int.Parse(block["dw"].ToString()) - 1, int.Parse(block["b"].ToString()), false,
                                                          lessonType, teacherName, roomName,

--- a/Backend/Converter/ConverterApiToDomain.cs
+++ b/Backend/Converter/ConverterApiToDomain.cs
@@ -91,9 +91,26 @@ namespace FRITeam.Swapify.Backend.Converter
 
                     if (!isTimetableForCourse)
                     {
-                        Course course = await (string.IsNullOrEmpty(firstInGroup.CourseName) ?
-                            courseService.GetOrAddNotExistsCourseByShortcut(firstInGroup.CourseShortcut) :
-                            courseService.GetOrAddNotExistsCourseByName(firstInGroup.CourseName, firstInGroup.CourseShortcut));
+                        Course course;
+                        if (!string.IsNullOrEmpty(firstInGroup.CourseName))
+                        {
+                            if (string.IsNullOrEmpty(firstInGroup.CourseShortcut))
+                            {
+                                course = await courseService.GetOrAddNotExistsCourseByName(firstInGroup.CourseName, firstInGroup.CourseShortcut);
+                            }
+                            else
+                            {
+                                course = await courseService.GetOrAddNotExistsCourseByShortcut(firstInGroup.CourseShortcut);
+                            }
+                        }
+                        else
+                        {
+                            course = await courseService.GetOrAddNotExistsCourseByShortcut(firstInGroup.CourseShortcut);
+                        }
+                        if (course == null)
+                        {
+                            throw new Exception("Course has no name, therefore it could not be added.");
+                        }
                         Block courseBlock = course.Timetable.GetBlock(block);
                         if (courseBlock != null)
                             block.BlockId = courseBlock.BlockId;


### PR DESCRIPTION
Issue was that uniza API was returning CourseName-s with spaces at the end. I added Triming to ResponseParser to fields CourseName and CourseShortcut. App was getting course from db by CourseName and if it did not find one it created new one. I changed it to get course by CourseShortcut. If it does not have CourseShortcut it gets it by CourseName. Possible issue: Db can be filled with courses with wrong CourseNames, which need to be removed.