### PR TITLE
373 panel subjects shows duplicates

### DIFF
--- a/APIWrapper/ResponseParser.cs
+++ b/APIWrapper/ResponseParser.cs
@@ -39,8 +39,8 @@ namespace FRITeam.Swapify.APIWrapper
                         LessonType lessonType = ConvertLessonType(block["tu"].ToString()[0]);
                         string teacherName = block["u"].ToString();
                         string roomName = block["r"].ToString();
-                        string subjectShortcut = block["k"].ToString();
-                        string subjectNameHelper = block["s"].ToString();
+                        string subjectShortcut = block["k"].ToString().Trim();
+                        string subjectNameHelper = block["s"].ToString().Trim();
                         string subjectName = subjectNameHelper.First().ToString().ToUpper() + subjectNameHelper.Substring(1);
                         var hourContent = new ScheduleHourContent(int.Parse(block["dw"].ToString()) - 1, int.Parse(block["b"].ToString()), false,
                                                          lessonType, teacherName, roomName,

--- a/Backend/Converter/ConverterApiToDomain.cs
+++ b/Backend/Converter/ConverterApiToDomain.cs
@@ -91,7 +91,7 @@ namespace FRITeam.Swapify.Backend.Converter
 
                     if (!isTimetableForCourse)
                     {
-                        Course course = null;
+                        Course course;
                         if (!string.IsNullOrEmpty(firstInGroup.CourseShortcut))
                         {
                         	course = await courseService.GetOrAddNotExistsCourseByShortcut(firstInGroup.CourseShortcut, firstInGroup.CourseName);   
@@ -99,11 +99,7 @@ namespace FRITeam.Swapify.Backend.Converter
                         else
                         {                                                        
                             course = await courseService.GetOrAddNotExistsCourseByName(firstInGroup.CourseName, firstInGroup.CourseShortcut);                            
-                        }
-                        if (course == null)
-                        {
-                            throw new Exception("Course has no name and no Shortcut, therefore it could not be added.");
-                        }
+                        }                        
                         Block courseBlock = course.Timetable.GetBlock(block);
                         if (courseBlock != null)
                             block.BlockId = courseBlock.BlockId;

--- a/Backend/Converter/ConverterApiToDomain.cs
+++ b/Backend/Converter/ConverterApiToDomain.cs
@@ -91,7 +91,7 @@ namespace FRITeam.Swapify.Backend.Converter
 
                     if (!isTimetableForCourse)
                     {
-                        Course course;
+                        Course course = null;
                         if (!string.IsNullOrEmpty(firstInGroup.CourseShortcut))
                         {
                         		course = await courseService.GetOrAddNotExistsCourseByShortcut(firstInGroup.CourseShortcut);   

--- a/Backend/Converter/ConverterApiToDomain.cs
+++ b/Backend/Converter/ConverterApiToDomain.cs
@@ -92,24 +92,17 @@ namespace FRITeam.Swapify.Backend.Converter
                     if (!isTimetableForCourse)
                     {
                         Course course;
-                        if (!string.IsNullOrEmpty(firstInGroup.CourseName))
+                        if (!string.IsNullOrEmpty(firstInGroup.CourseShortcut))
                         {
-                            if (string.IsNullOrEmpty(firstInGroup.CourseShortcut))
-                            {
-                                course = await courseService.GetOrAddNotExistsCourseByName(firstInGroup.CourseName, firstInGroup.CourseShortcut);
-                            }
-                            else
-                            {
-                                course = await courseService.GetOrAddNotExistsCourseByShortcut(firstInGroup.CourseShortcut);
-                            }
+                        		course = await courseService.GetOrAddNotExistsCourseByShortcut(firstInGroup.CourseShortcut);   
                         }
-                        else
-                        {
-                            course = await courseService.GetOrAddNotExistsCourseByShortcut(firstInGroup.CourseShortcut);
+                        else if (!string.IsNullOrEmpty(firstInGroup.CourseName))
+                        {                                                        
+                            course = await courseService.GetOrAddNotExistsCourseByName(firstInGroup.CourseName, firstInGroup.CourseShortcut);                            
                         }
                         if (course == null)
                         {
-                            throw new Exception("Course has no name, therefore it could not be added.");
+                            throw new Exception("Course has no name and no Shortcut, therefore it could not be added.");
                         }
                         Block courseBlock = course.Timetable.GetBlock(block);
                         if (courseBlock != null)

--- a/Backend/Converter/ConverterApiToDomain.cs
+++ b/Backend/Converter/ConverterApiToDomain.cs
@@ -94,9 +94,9 @@ namespace FRITeam.Swapify.Backend.Converter
                         Course course = null;
                         if (!string.IsNullOrEmpty(firstInGroup.CourseShortcut))
                         {
-                        		course = await courseService.GetOrAddNotExistsCourseByShortcut(firstInGroup.CourseShortcut);   
+                        	course = await courseService.GetOrAddNotExistsCourseByShortcut(firstInGroup.CourseShortcut, firstInGroup.CourseName);   
                         }
-                        else if (!string.IsNullOrEmpty(firstInGroup.CourseName))
+                        else
                         {                                                        
                             course = await courseService.GetOrAddNotExistsCourseByName(firstInGroup.CourseName, firstInGroup.CourseShortcut);                            
                         }

--- a/Backend/Converter/ConverterApiToDomain.cs
+++ b/Backend/Converter/ConverterApiToDomain.cs
@@ -91,9 +91,26 @@ namespace FRITeam.Swapify.Backend.Converter
 
                     if (!isTimetableForCourse)
                     {
-                        Course course = await (string.IsNullOrEmpty(firstInGroup.CourseName) ?
-                            courseService.GetOrAddNotExistsCourseByShortcut(firstInGroup.CourseShortcut) :
-                            courseService.GetOrAddNotExistsCourseByName(firstInGroup.CourseName, firstInGroup.CourseShortcut));
+                        Course course;
+                        if (!string.IsNullOrEmpty(firstInGroup.CourseName))
+                        {
+                            if (string.IsNullOrEmpty(firstInGroup.CourseShortcut))
+                            {
+                                course = await courseService.GetOrAddNotExistsCourseByName(firstInGroup.CourseName, firstInGroup.CourseShortcut);
+                            }
+                            else
+                            {
+                                course = await courseService.GetOrAddNotExistsCourseByShortcut(firstInGroup.CourseShortcut);
+                            }
+                        }
+                        else
+                        {
+                            course = await courseService.GetOrAddNotExistsCourseByShortcut(firstInGroup.CourseShortcut);
+                        }
+                        if (course == null)
+                        {
+                            throw new Exception("Course has no name, therefore it could not be added.");
+                        }
                         Block courseBlock = course.Timetable.GetBlock(block);
                         if (courseBlock != null)
                             block.BlockId = courseBlock.BlockId;

--- a/Backend/CourseService.cs
+++ b/Backend/CourseService.cs
@@ -58,13 +58,13 @@ namespace FRITeam.Swapify.Backend
         /// If course with "courseName" exists function return ID, if course doesnt exist fuction
         /// save this course and return id of saved course.
         /// </summary>
-        public async Task<Course> GetOrAddNotExistsCourseByShortcut(string courseShortcut)
+        public async Task<Course> GetOrAddNotExistsCourseByShortcut(string courseShortcut, string courseName = null)
         {
             var course = await this.FindByCodeAsync(courseShortcut);
             if (course == null)
             {
                 var timetable = new Timetable();
-                course = new Course() { CourseCode = courseShortcut, Timetable = timetable, IsLoaded = false };
+                course = new Course() { CourseCode = courseShortcut, Timetable = timetable, IsLoaded = false, CourseName = courseName };
                 string shortCut = FindCourseShortCutFromProxy(course);
                 await FindCourseTimetableFromProxy(shortCut, course);
                 

--- a/Backend/Interfaces/ICourseService.cs
+++ b/Backend/Interfaces/ICourseService.cs
@@ -12,7 +12,7 @@ namespace FRITeam.Swapify.Backend.Interfaces
         Task<Course> FindByIdAsync(Guid guid);
         Task<Course> FindByNameAsync(string name);
         List<Course> FindByStartName(string courseStartsWith);
-        Task<Course> GetOrAddNotExistsCourseByShortcut(string courseShortcut);
+        Task<Course> GetOrAddNotExistsCourseByShortcut(string courseShortcut, string courseName = null);
         Task<Course> GetOrAddNotExistsCourseByName(string courseName, string courseCode);
         string FindCourseShortCutFromProxy(Course course);
         Task<Course> FindCourseTimetableFromProxy(Guid guid);


### PR DESCRIPTION
Issue was that uniza API was returning CourseName-s with spaces at the end. I added Triming to ResponseParser to fields CourseName and CourseShortcut. App was getting course from db by CourseName and if it did not find one it created new one. I changed it to get course by CourseShortcut. If it does not have CourseShortcut it gets it by CourseName. Possible issue: Db can be filled with courses with wrong CourseNames, which need to be removed.