### PR TITLE
373 panel subjects shows duplicates 

### DIFF
--- a/APIWrapper/ResponseParser.cs
+++ b/APIWrapper/ResponseParser.cs
@@ -39,8 +39,8 @@ namespace FRITeam.Swapify.APIWrapper
                         LessonType lessonType = ConvertLessonType(block["tu"].ToString()[0]);
                         string teacherName = block["u"].ToString();
                         string roomName = block["r"].ToString();
-                        string subjectShortcut = block["k"].ToString();
-                        string subjectNameHelper = block["s"].ToString();
+                        string subjectShortcut = block["k"].ToString().Trim();
+                        string subjectNameHelper = block["s"].ToString().Trim();
                         string subjectName = subjectNameHelper.First().ToString().ToUpper() + subjectNameHelper.Substring(1);
                         var hourContent = new ScheduleHourContent(int.Parse(block["dw"].ToString()) - 1, int.Parse(block["b"].ToString()), false,
                                                          lessonType, teacherName, roomName,

--- a/Backend/Converter/ConverterApiToDomain.cs
+++ b/Backend/Converter/ConverterApiToDomain.cs
@@ -94,7 +94,7 @@ namespace FRITeam.Swapify.Backend.Converter
                         Course course;
                         if (!string.IsNullOrEmpty(firstInGroup.CourseShortcut))
                         {
-                        	course = await courseService.GetOrAddNotExistsCourseByShortcut(firstInGroup.CourseShortcut, firstInGroup.CourseName);   
+                        		course = await courseService.GetOrAddNotExistsCourseByShortcut(firstInGroup.CourseShortcut, firstInGroup.CourseName);   
                         }
                         else
                         {                                                        

--- a/Backend/Converter/ConverterApiToDomain.cs
+++ b/Backend/Converter/ConverterApiToDomain.cs
@@ -91,15 +91,7 @@ namespace FRITeam.Swapify.Backend.Converter
 
                     if (!isTimetableForCourse)
                     {
-                        Course course;
-                        if (!string.IsNullOrEmpty(firstInGroup.CourseShortcut))
-                        {
-                        		course = await courseService.GetOrAddNotExistsCourseByShortcut(firstInGroup.CourseShortcut, firstInGroup.CourseName);   
-                        }
-                        else
-                        {                                                        
-                            course = await courseService.GetOrAddNotExistsCourseByName(firstInGroup.CourseName, firstInGroup.CourseShortcut);                            
-                        }                        
+                        Course course = await courseService.GetOrAddNotExistsCourse(firstInGroup.CourseShortcut, firstInGroup.CourseName);                                                
                         Block courseBlock = course.Timetable.GetBlock(block);
                         if (courseBlock != null)
                             block.BlockId = courseBlock.BlockId;

--- a/Backend/Converter/ConverterApiToDomain.cs
+++ b/Backend/Converter/ConverterApiToDomain.cs
@@ -91,9 +91,15 @@ namespace FRITeam.Swapify.Backend.Converter
 
                     if (!isTimetableForCourse)
                     {
-                        Course course = await (string.IsNullOrEmpty(firstInGroup.CourseName) ?
-                            courseService.GetOrAddNotExistsCourseByShortcut(firstInGroup.CourseShortcut) :
-                            courseService.GetOrAddNotExistsCourseByName(firstInGroup.CourseName, firstInGroup.CourseShortcut));
+                        Course course;
+                        if (!string.IsNullOrEmpty(firstInGroup.CourseShortcut))
+                        {
+                        	course = await courseService.GetOrAddNotExistsCourseByShortcut(firstInGroup.CourseShortcut, firstInGroup.CourseName);   
+                        }
+                        else
+                        {                                                        
+                            course = await courseService.GetOrAddNotExistsCourseByName(firstInGroup.CourseName, firstInGroup.CourseShortcut);                            
+                        }                        
                         Block courseBlock = course.Timetable.GetBlock(block);
                         if (courseBlock != null)
                             block.BlockId = courseBlock.BlockId;

--- a/Backend/CourseService.cs
+++ b/Backend/CourseService.cs
@@ -55,8 +55,8 @@ namespace FRITeam.Swapify.Backend
         }
 
         /// <summary>
-        /// If course with "courseName" exists function return ID, if course doesnt exist fuction
-        /// save this course and return id of saved course.
+        /// If course with exists, function returns ID. If course doesnt exist function
+        /// saves this course and returns id of saved course.
         /// </summary>
         public async Task<Course> GetOrAddNotExistsCourse(string courseShortcut, string courseName)
         {

--- a/Backend/CourseService.cs
+++ b/Backend/CourseService.cs
@@ -58,16 +58,15 @@ namespace FRITeam.Swapify.Backend
         /// If course with "courseName" exists function return ID, if course doesnt exist fuction
         /// save this course and return id of saved course.
         /// </summary>
-        public async Task<Course> GetOrAddNotExistsCourseByShortcut(string courseShortcut, string courseName = null)
+        public async Task<Course> GetOrAddNotExistsCourse(string courseShortcut, string courseName)
         {
-            var course = await this.FindByCodeAsync(courseShortcut);
+            var course = await (string.IsNullOrEmpty(courseShortcut) ? this.FindByCodeAsync(courseName) : this.FindByCodeAsync(courseShortcut));
             if (course == null)
             {
                 var timetable = new Timetable();
                 course = new Course() { CourseCode = courseShortcut, Timetable = timetable, IsLoaded = false, CourseName = courseName };
                 string shortCut = FindCourseShortCutFromProxy(course);
-                await FindCourseTimetableFromProxy(shortCut, course);
-                
+                await FindCourseTimetableFromProxy(shortCut, course);                
                 await this.AddAsync(course);
             }
             else
@@ -81,33 +80,7 @@ namespace FRITeam.Swapify.Backend
                 }
             }
             return course;
-        }
-
-        public async Task<Course> GetOrAddNotExistsCourseByName(string courseName, string courseCode)
-        {
-            var course = await this.FindByNameAsync(courseName);
-            if (course == null)
-            {
-                var timetable = new Timetable();
-                course = new Course() { CourseCode = courseCode, CourseName = courseName, Timetable = timetable, IsLoaded = false };
-                string shortCut = FindCourseShortCutFromProxy(course);
-                await FindCourseTimetableFromProxy(shortCut, course);
-
-                await this.AddAsync(course);
-            }
-            else
-            {
-                if (course.Timetable == null || !course.IsLoaded)
-                {
-                    course.Timetable = new Timetable();
-                    string shortCut = this.FindCourseShortCutFromProxy(course);
-                    await this.FindCourseTimetableFromProxy(shortCut, course);
-                    await this.UpdateAsync(course);
-                }
-            }
-            return course;
-        }
-
+        }       
         public string FindCourseShortCutFromProxy(Course course)
         {
             foreach (var _course in _courseProxy.GetByCourseName(course.CourseName))

--- a/Backend/CourseService.cs
+++ b/Backend/CourseService.cs
@@ -60,7 +60,7 @@ namespace FRITeam.Swapify.Backend
         /// </summary>
         public async Task<Course> GetOrAddNotExistsCourse(string courseShortcut, string courseName)
         {
-            var course = await (string.IsNullOrEmpty(courseShortcut) ? this.FindByCodeAsync(courseName) : this.FindByCodeAsync(courseShortcut));
+            var course = await (string.IsNullOrEmpty(courseShortcut) ? this.FindByNameAsync(courseName) : this.FindByCodeAsync(courseShortcut));
             if (course == null)
             {
                 var timetable = new Timetable();

--- a/Backend/CourseService.cs
+++ b/Backend/CourseService.cs
@@ -58,13 +58,13 @@ namespace FRITeam.Swapify.Backend
         /// If course with "courseName" exists function return ID, if course doesnt exist fuction
         /// save this course and return id of saved course.
         /// </summary>
-        public async Task<Course> GetOrAddNotExistsCourseByShortcut(string courseShortcut)
+        public async Task<Course> GetOrAddNotExistsCourseByShortcut(string courseShortcut, string courseName = null)
         {
             var course = await this.FindByCodeAsync(courseShortcut);
             if (course == null)
             {
                 var timetable = new Timetable();
-                course = new Course() { CourseCode = courseShortcut, Timetable = timetable, IsLoaded = false };
+                course = new Course() { CourseCode = courseShortcut, Timetable = timetable, IsLoaded = false, CourseName = courseName };
                 string shortCut = FindCourseShortCutFromProxy(course);
                 await FindCourseTimetableFromProxy(shortCut, course);
                 

--- a/Backend/Interfaces/ICourseService.cs
+++ b/Backend/Interfaces/ICourseService.cs
@@ -12,7 +12,7 @@ namespace FRITeam.Swapify.Backend.Interfaces
         Task<Course> FindByIdAsync(Guid guid);
         Task<Course> FindByNameAsync(string name);
         List<Course> FindByStartName(string courseStartsWith);
-        Task<Course> GetOrAddNotExistsCourseByShortcut(string courseShortcut);
+        Task<Course> GetOrAddNotExistsCourseByShortcut(string courseShortcut, string courseName = null);
         Task<Course> GetOrAddNotExistsCourseByName(string courseName, string courseCode);
         string FindCourseShortCutFromProxy(Course course);
         Task<Course> FindCourseTimetableFromProxy(Guid guid);

--- a/Backend/Interfaces/ICourseService.cs
+++ b/Backend/Interfaces/ICourseService.cs
@@ -12,8 +12,7 @@ namespace FRITeam.Swapify.Backend.Interfaces
         Task<Course> FindByIdAsync(Guid guid);
         Task<Course> FindByNameAsync(string name);
         List<Course> FindByStartName(string courseStartsWith);
-        Task<Course> GetOrAddNotExistsCourseByShortcut(string courseShortcut, string courseName = null);
-        Task<Course> GetOrAddNotExistsCourseByName(string courseName, string courseCode);
+        Task<Course> GetOrAddNotExistsCourse(string courseShortcut, string courseName);        
         string FindCourseShortCutFromProxy(Course course);
         Task<Course> FindCourseTimetableFromProxy(Guid guid);
         Task<Course> FindCourseTimetableFromProxy(string shortCut, Course course);

--- a/WebAPI/Controllers/StudentController.cs
+++ b/WebAPI/Controllers/StudentController.cs
@@ -102,7 +102,7 @@ namespace WebAPI.Controllers
             }
 
             TimetableBlock timetableBlock = newBlockModel.TimetableBlock;
-            Course course = await _courseService.GetOrAddNotExistsCourseByName(timetableBlock.CourseName, timetableBlock.CourseShortcut);
+            Course course = await _courseService.GetOrAddNotExistsCourse(timetableBlock.CourseName, timetableBlock.CourseShortcut);
 
             if (course == null)
             {

--- a/WebAPI/Controllers/StudentController.cs
+++ b/WebAPI/Controllers/StudentController.cs
@@ -102,7 +102,7 @@ namespace WebAPI.Controllers
             }
 
             TimetableBlock timetableBlock = newBlockModel.TimetableBlock;
-            Course course = await _courseService.GetOrAddNotExistsCourse(timetableBlock.CourseName, timetableBlock.CourseShortcut);
+            Course course = await _courseService.GetOrAddNotExistsCourse(timetableBlock.CourseShortcut, timetableBlock.CourseName);
 
             if (course == null)
             {


### PR DESCRIPTION
Issue was that uniza API was returning CourseName-s with spaces at the end. I added Triming to ResponseParser to fields CourseName and CourseShortcut. App was getting course from db by CourseName and if it did not find one it created new one. I changed it to get course by CourseShortcut. If it does not have CourseShortcut it gets it by CourseName. Possible issue: Db can be filled with courses with wrong CourseNames, which need to be removed.