### PR TITLE
#305 wrg credentials msg changed

### DIFF
--- a/Tests/BackendTest/UserControllerTests/UserControllerTests.cs
+++ b/Tests/BackendTest/UserControllerTests/UserControllerTests.cs
@@ -385,11 +385,8 @@ namespace BackendTest.UserControllerTests
 
             var result = await controller.Login(loginModel);
 
-            Assert.IsType<BadRequestObjectResult>(result);
-
-            dynamic badRequestObject = (BadRequestObjectResult)result;
-            string error = badRequestObject.Value.Error;
-            Assert.Equal($"Používateľ {TesterEmail} neexistuje.", error);
+            // Don't show if user with this email exists
+            Assert.IsType<OkObjectResult>(result);
         }
 
         [Fact]
@@ -435,7 +432,7 @@ namespace BackendTest.UserControllerTests
 
             dynamic badRequestObject = (BadRequestObjectResult)result;
             string error = badRequestObject.Value.Error;
-            Assert.Equal("Zadané heslo nie je správne.", error);
+            Assert.Equal("E-mailová adresa a heslo nie sú správne.", error);
 
         }
 
@@ -474,11 +471,8 @@ namespace BackendTest.UserControllerTests
 
             var result = await controller.ResetPassword(resetPassModel);
 
-            Assert.IsType<BadRequestObjectResult>(result);
-
-            dynamic badRequestObject = (BadRequestObjectResult)result;
-            string error = badRequestObject.Value.Error;
-            Assert.Equal($"Používateľ {TesterEmail} neexistuje.", error);
+            // Yes, reset password email sent message even when user doesn't have to exist
+            Assert.IsType<OkResult>(result);
         }
 
         [Fact]
@@ -612,7 +606,8 @@ namespace BackendTest.UserControllerTests
 
             var result = await controller.SendEmailConfirmTokenAgain(sendEmailConfirmTokenModel);
 
-            Assert.IsType<BadRequestObjectResult>(result);
+            // expect Ok result anyway, it's not revealed if user exists
+            Assert.IsType<OkResult>(result);
         }
 
         [Fact]

--- a/Tests/BackendTest/UserControllerTests/UserControllerTests.cs
+++ b/Tests/BackendTest/UserControllerTests/UserControllerTests.cs
@@ -385,8 +385,11 @@ namespace BackendTest.UserControllerTests
 
             var result = await controller.Login(loginModel);
 
-            // Don't show if user with this email exists
-            Assert.IsType<OkObjectResult>(result);
+            Assert.IsType<BadRequestObjectResult>(result);
+
+            //dynamic badRequestObject = (BadRequestObjectResult)result;
+            //string error = badRequestObject.Value.Error;
+            //Assert.Equal($"Používateľ {TesterEmail} neexistuje.", error);
         }
 
         [Fact]

--- a/WebAPI/Controllers/UserController.cs
+++ b/WebAPI/Controllers/UserController.cs
@@ -143,7 +143,7 @@ namespace WebAPI.Controllers
             if (user == null)
             {
                 _logger.LogWarning($"Invalid send confirmation email attempt. User {body.Email} doesn't exist.");
-                return ErrorResponse($"Používateľ {body.Email} neexistuje.");
+                return Ok();
             }
 
             if (user.EmailConfirmed)
@@ -172,7 +172,7 @@ namespace WebAPI.Controllers
                 if (user == null)
                 {
                     _logger.LogInformation($"Invalid login attemp. User {body.Email} doesn't exist.");
-                    return ErrorResponse($"Používateľ {body.Email} neexistuje.");
+                    return ErrorResponse($"E-mailová adresa a heslo nie sú správne.");
                 }
 
                 if (!user.EmailConfirmed)
@@ -185,7 +185,7 @@ namespace WebAPI.Controllers
                 if (token == null)
                 {
                     _logger.LogWarning($"Invalid login attemp. User {body.Email} entered wrong password.");
-                    return ErrorResponse("Zadané heslo nie je správne.");
+                    return ErrorResponse($"E-mailová adresa a heslo nie sú správne.");
                 }
 
                 var authUser = new AuthenticatedUserModel(user, token);
@@ -214,7 +214,7 @@ namespace WebAPI.Controllers
             if (user == null)
             {
                 _logger.LogInformation($"Invalid password reset attemp. User {body.Email} doesn't exist.");
-                return ErrorResponse($"Používateľ {body.Email} neexistuje.");
+                return Ok();
             }
 
             if (!user.EmailConfirmed)


### PR DESCRIPTION
Messages if password or email are incorrect were changed.

Login:
![image](https://user-images.githubusercontent.com/43585019/100078427-cce24700-2e43-11eb-8837-a2e7c29c7c3d.png)

Correct message is now shown, even if e-mail doesn't exist.

Reset:
![image](https://user-images.githubusercontent.com/43585019/100078547-ee433300-2e43-11eb-8175-77c8ca75f84f.png)
