### PR TITLE
Unncessary dialog window #475

### DIFF
--- a/WebAPI/Controllers/ExchangeController.cs
+++ b/WebAPI/Controllers/ExchangeController.cs
@@ -83,16 +83,13 @@ namespace WebAPI.Controllers
                     {
                         string message = $"Error when sending confirmation email to user {user1.Email}.";
                         _logger.LogError(message);
-                        //return NotFound(message);
                     }
 
                     if (!_emailService.SendConfirmationEmail(user2.Email, callbackUrl2, "ConfirmExchangeEmail"))
                     {
                         string message = $"Error when sending confirmation email to user {user2.Email}.";
                         _logger.LogError(message);
-                        //return NotFound(message);
                     }
-
                     return Ok(res);
                 }
                 return Ok(null);

--- a/WebAPI/Controllers/ExchangeController.cs
+++ b/WebAPI/Controllers/ExchangeController.cs
@@ -83,17 +83,19 @@ namespace WebAPI.Controllers
                     {
                         string message = $"Error when sending confirmation email to user {user1.Email}.";
                         _logger.LogError(message);
-                        return NotFound(message);
+                        //return NotFound(message);
                     }
 
                     if (!_emailService.SendConfirmationEmail(user2.Email, callbackUrl2, "ConfirmExchangeEmail"))
                     {
                         string message = $"Error when sending confirmation email to user {user2.Email}.";
                         _logger.LogError(message);
-                        return NotFound(message);
+                        //return NotFound(message);
                     }
+
+                    return Ok(res);
                 }
-                return Ok(res);
+                return Ok(null);
             }
             catch
             {

--- a/WebApp/src/actions/timetableActions.js
+++ b/WebApp/src/actions/timetableActions.js
@@ -205,7 +205,7 @@ export function exchangeConfirm(blockTo) {
     })
       .then((response) => { 
         var exchangeMade = response.data;
-        if (exchangeMade === false) {
+        if (exchangeMade === "") {
           window.alert("Žiadosť o výmenu bola evidovaná.");          
         } else {          
           window.alert("Výmena bola vykonaná.");  

--- a/WebApp/src/actions/timetableActions.js
+++ b/WebApp/src/actions/timetableActions.js
@@ -215,8 +215,21 @@ export function exchangeConfirm(blockTo) {
         dispatch(action);       
         dispatch(loadExchangeRequests());
       })
-      .catch(() => {
-        window.alert("Pri vytváraní žiadosti nastala chyba.");
+      .catch((error) => {        
+        if (error.response) {
+          window.alert("Pri vytváraní žiadosti nastala chyba.");
+          // The request was made and the server responded with a status code
+          // that falls out of the range of 2xx
+        } else if (error.request) {
+          window.alert("Nepodarilo sa nadviazať spojenie so serverom.");
+          // The request was made but no response was received
+          // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
+          // http.ClientRequest in node.js
+        } else {
+          // Something happened in setting up the request that triggered an Error
+          console.log('Error', error.message);          
+          //This error shows undefined history after creating request
+        }        
         dispatch(hideCourseTimetable(bl.id));
         dispatch({
           type: CANCEL_EXCHANGE_MODE


### PR DESCRIPTION
Closes #475 
Pop-up window was showing up because of "history is undefined" error which im not really sure what means. There were som informations about this error regardig to Reacts routing but i found no relation to axios or post. And im not sure what and if we should do something with this error or prevent it somehow. As of now i found no way how to fix this error, and when back arrow is pressed after creating "change subject request", im navigated back to window where i choose personal number, which is correct in my opinion. I changed the catch block, so now it shows only for response error from server or bad request to server. Other errors will be printed on console for now.